### PR TITLE
redesign: 重新设计 Recent Blog Posts 区块视觉样式

### DIFF
--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -147,25 +147,33 @@ Awesome CS · Cloud Native · Blockchain learning resources and notes.<br/>
 
 ## 📜 Recent Blog Posts
 
+<p align="center">
+  <a href="https://nsddd.top/index.xml"><img src="https://img.shields.io/badge/RSS-English-orange?style=flat-square&logo=rss&logoColor=white"/></a>
+  &nbsp;
+  <a href="https://nsddd.top/zh/index.xml"><img src="https://img.shields.io/badge/RSS-中文-red?style=flat-square&logo=rss&logoColor=white"/></a>
+</p>
+
 <table width="100%">
 <tr>
-<td width="50%" valign="top">
-
-**🌐 English**
+<th width="50%" align="left">🌐 English</th>
+<th width="50%" align="left">🌏 中文</th>
+</tr>
+<tr>
+<td valign="top">
 
 {{range rss "https://nsddd.top/index.xml" 5}}
-- [{{.Title}}]({{.URL}}) <small>_({{humanize .PublishedAt}})_</small>
-{{- end}}
+📌 **[{{.Title}}]({{.URL}})**
+<sub>🕐 {{humanize .PublishedAt}}</sub>
 
+{{ end}}
 </td>
-<td width="50%" valign="top">
-
-**🌏 中文**
+<td valign="top">
 
 {{range rss "https://nsddd.top/zh/index.xml" 5}}
-- [{{.Title}}]({{.URL}}) <small>_({{humanize .PublishedAt}})_</small>
-{{- end}}
+📌 **[{{.Title}}]({{.URL}})**
+<sub>🕐 {{humanize .PublishedAt}}</sub>
 
+{{ end}}
 </td>
 </tr>
 </table>


### PR DESCRIPTION
## 关联 Issue

Closes #18

## 改动说明

重新设计 `templates/README.md.tpl` 中的 **Recent Blog Posts** 区块，从平淡的纯文本列表升级为更有视觉层次的卡片式布局。

## 前后对比

### 改动前

```
**🌐 English**

- [Post Title](url) _(2 days ago)_
- [Post Title](url) _(1 week ago)_
```

### 改动后

```
[ RSS English badge ] [ RSS 中文 badge ]

| 🌐 English                        | 🌏 中文                          |
|-----------------------------------|----------------------------------|
| 📌 **[Post Title](url)**          | 📌 **[文章标题](url)**           |
|   🕐 2 days ago                   |   🕐 3 天前                      |
```

## 具体改动

| 改动项 | 改动前 | 改动后 |
|--------|--------|--------|
| 区块标题行 | 无 badge | RSS 订阅 badge（英文 + 中文） |
| 表头 | `**🌐 English**` 普通加粗 | `<th>` 表头，视觉权重更强 |
| 文章条目 | `- [title](url) _(date)_` | `📌 **[title](url)**` + 独行日期 |
| 日期样式 | 行内 `<small>` 斜体 | 独立 `<sub>🕐 date</sub>` |
| 条目间距 | 无空行 | 空行分隔，可读性更好 |

## 验收

- [x] 模板语法保持 markscribe 兼容（`{{range rss ...}}` 语法不变）
- [x] 英文 / 中文两列都已更新
- [x] RSS badge 链接指向正确的 feed 地址

https://claude.ai/code/session_01LxDsvCz6oKGFCxYJWM8kMv